### PR TITLE
remove leading whitespace before parsing and comparison

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -8,4 +8,7 @@ module.exports = function format(html) {
     .replace(/\s{2,}/g, ' ')
     // Remove whitespace between elements
     .replace(/>\s+</g, '><')
+    // Remove leading whitespace
+    .replace(/^\s+/g, '')
+
 }

--- a/lib/format.js
+++ b/lib/format.js
@@ -9,6 +9,5 @@ module.exports = function format(html) {
     // Remove whitespace between elements
     .replace(/>\s+</g, '><')
     // Remove leading and trailing whitespace
-    .trim();
-
+    .trim()
 }

--- a/lib/format.js
+++ b/lib/format.js
@@ -8,7 +8,7 @@ module.exports = function format(html) {
     .replace(/\s{2,}/g, ' ')
     // Remove whitespace between elements
     .replace(/>\s+</g, '><')
-    // Remove leading whitespace
-    .replace(/^\s+/g, '')
+    // Remove leading and trailing whitespace
+    .trim();
 
 }

--- a/tests/spec/chai-html.js
+++ b/tests/spec/chai-html.js
@@ -37,6 +37,11 @@ describe('Chai HTML', () => {
         .html.to.equal('<div> <img> </div>')
     })
 
+    it('does not fret about leading whitespace', () => {
+      expect('  \t<div> <img> </div>')
+        .html.to.equal('<div> <img> </div>')
+    })
+
     it('does not baulk at comparing self-closing and unclosed elements', () => {
       expect('<div><br><hr /></div>')
         .html.to.equal('<div><br /><hr></div>')

--- a/tests/spec/chai-html.js
+++ b/tests/spec/chai-html.js
@@ -42,6 +42,11 @@ describe('Chai HTML', () => {
         .html.to.equal('<div> <img> </div>')
     })
 
+    it('does not fret about trailing whitespace', () => {
+      expect('<div> <img> </div> \t   ')
+        .html.to.equal('<div> <img> </div>')
+    })
+
     it('does not baulk at comparing self-closing and unclosed elements', () => {
       expect('<div><br><hr /></div>')
         .html.to.equal('<div><br /><hr></div>')


### PR DESCRIPTION
I had a problem with failing comparisons between two html strings when one has leading whitespace e.g.
```html
     <a class="link" href="http://google.com">google</a>
```
vs

```html
<a class="link" href="http://google.com">google</a>
```

removing this whitespace before parsing the strings solves this issue