### PR TITLE
Add .ignoringcomments property

### DIFF
--- a/lib/chai-html.js
+++ b/lib/chai-html.js
@@ -14,6 +14,10 @@ function chaiHtmlPlugin (chai, utils) {
     utils.flag(this, 'html', true)
   })
 
+  chai.Assertion.addProperty('ignoringcomments', function () {
+    utils.flag(this, 'ignoringcomments', true)
+  })
+
   function compare (_super) {
     return function (value) {
       if (utils.flag(this, 'html')) {
@@ -23,8 +27,12 @@ function chaiHtmlPlugin (chai, utils) {
         const lhsTree = parse5.parseFragment(lhsFormatted)
         const rhsTree = parse5.parseFragment(rhsFormatted)
 
-        normalize(lhsTree)
-        normalize(rhsTree)
+        const options = {
+          ignoreComments: utils.flag(this, 'ignoringcomments')
+        }
+
+        normalize(lhsTree, options)
+        normalize(rhsTree, options)
 
         // deep-diff 0.3.6 trips on circular references
         const ignore = (path, key) => key === 'parentNode'

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -42,17 +42,42 @@ function whitespace (childNodes) {
   })
 }
 
-module.exports = function normalize (tree) {
+function removeComments (childNodes) {
+  childNodes = childNodes.filter(x => x.nodeName !== '#comment')
+  // Removing comments might leave text nodes next to each other,
+  // in which case we should join them together into one node.
+  const toRemove = []
+  for (let i = 0; i < childNodes.length; i++) {
+    if (childNodes[i].nodeName === '#text') {
+      let endOfTextNodeChunk = childNodes.findIndex((node, index) => node.nodeName !== '#text' && index > i)
+      if (endOfTextNodeChunk === -1) {
+        endOfTextNodeChunk = childNodes.length - 1
+      }
+      for (let j = i + 1; j <= endOfTextNodeChunk; j++) {
+        childNodes[i].value += childNodes[j].value
+        toRemove.push(childNodes[j])
+      }
+      i = endOfTextNodeChunk + 1
+    }
+  }
+  return childNodes.filter(x => !toRemove.includes(x))
+}
+
+module.exports = function normalize (tree, options) {
   if (Array.isArray(tree)) {
-    tree.forEach(normalize)
+    tree.forEach(x => normalize(x, options))
   } else {
     if (tree.attrs) {
       tree.attrs = attributes(tree.attrs)
     }
 
     if (tree.childNodes) {
+      if (options.ignoreComments) {
+        tree.childNodes = removeComments(tree.childNodes)
+      }
+
       whitespace(tree.childNodes)
-      normalize(tree.childNodes)
+      normalize(tree.childNodes, options)
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,13 @@ expect('<p>Hello World!</p> Hej!').html.to.equal('<p>Hello World!</p>')
 // throws: text " Hej!" has been removed
 ```
 
+### .ignoringcomments
+Include the `ignoringcomments` property to ignore HTML comments.
+
+```js
+expect('<div><!--Comment--></div>').html.ignoringcomments.to.equal('<div></div>')
+```
+
 ## How does it work?
 
 Underneath this plugin uses [parse5](https://github.com/inikulin/parse5) to parse the given HTML strings and normalize the generated trees before being compared. This means that although the two strings of markup may not be the same they should generate equivalent structures.

--- a/tests/fixtures/article-d.html
+++ b/tests/fixtures/article-d.html
@@ -1,0 +1,30 @@
+<!--This is the same as article c, but with comments-->
+<article class="BlogPost BlogPost--listing" itemscope itemtype="http://schema.org/BlogPosting">
+  <a class="BlogPost-permalink" href="/2015/12/14/svg-icons-are-easy-but-the-fallbacks-arent.html" rel="bookmark" itemprop="url">
+<!--
+A comment
+
+spanning
+
+multiple lines
+with HTML!
+<div></div>
+
+
+-->
+    
+    <h2 class="BlogPost-title" itemprop="name">
+      SVG icons are easy<!--Comment in content!--> but the fallbacks aren't
+    </h2>
+
+    <div class="BlogPost-meta">
+      <time class="BlogPost-metaDate" datetime="2015-12-14" itemprop="datePublished">
+        14 December 2015
+      </time>
+    </div>
+
+    <p class="BlogPost-excerpt BlogPost-sabotaged">
+      Use of the icon font is in decline.<!--Comment--> Recently<!--comment--><!--comment--> it’s been argued that there are many good reasons to think about not using them and switch to using SVG images instead. At the Financial Times we must provision proper fallbacks for much of the 4% of browsers that don't support SVG. As it turns out, that's hard. <span class="BlogPost-readMore">Read more</span>
+    </p>
+  </a>
+</article>

--- a/tests/spec/chai-html.js
+++ b/tests/spec/chai-html.js
@@ -13,6 +13,7 @@ chai.use(chaiHtml)
 const a = fs.readFileSync(path.join(__dirname, '/../fixtures/article-a.html')).toString()
 const b = fs.readFileSync(path.join(__dirname, '/../fixtures/article-b.html')).toString()
 const c = fs.readFileSync(path.join(__dirname, '/../fixtures/article-c.html')).toString()
+const d = fs.readFileSync(path.join(__dirname, '/../fixtures/article-d.html')).toString()
 
 describe('Chai HTML', () => {
   describe('the plugin', () => {
@@ -74,6 +75,26 @@ describe('Chai HTML', () => {
     it('can handle large HTML chunks', () => {
       expect(a).html.to.equal(b)
       expect(a).html.to.not.equal(c)
+    })
+
+    describe('ignoringcomments', () => {
+      it('does not ignore comments if ignoringcomments option not set', () => {
+        expect('<div><!--Comment--></div>').html.to.not.equal('<div></div>')
+      })
+
+      it('ignores comments if ignoringcomments option set', () => {
+        expect('<div><!--Comment--></div>').html.ignoringcomments.to.equal(
+          '<div/>'
+        )
+      })
+
+      it('ignores comments in the middle of text', () => {
+        expect('<div>aaa<!--comment-->bbb</div>').html.ignoringcomments.to.equal('<div>aaabbb</div>')
+      })
+
+      it('ignores complex comments if ignorecomments option set', () => {
+        expect(c).html.ignoringcomments.to.equal(d)
+      })
     })
   })
 


### PR DESCRIPTION
Resolves #23
Adds an .ignoringcomments property, for example:
```js
expect('<div><!--Comment--></div>').html.ignoringcomments.to.equal('<div></div>')
```