### PR TITLE
feat: Report differences for comments

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -3,6 +3,8 @@
 function thing (ast) {
   if (ast.nodeName === '#text') {
     return `text "${ast.value}"`
+  } else if (ast.nodeName === '#comment') {
+    return `comment "${ast.data}"`
   } else if (ast.tagName) {
     return `tag <${ast.tagName}>`
   } else if (ast.name && ast.value) {

--- a/tests/spec/chai-html.js
+++ b/tests/spec/chai-html.js
@@ -145,6 +145,14 @@ describe('Chai HTML', () => {
           expect(e.message).to.equal('text "Hej world!" was changed to text "Hello world!"')
         }
       })
+
+      it('detects comment changes', () => {
+        try {
+          expect('<p>Hello world!</p><!-- Hello -->').html.to.equal('<p>Hello world!</p><!-- Hej -->')
+        } catch (e) {
+          expect(e.message).to.equal('comment " Hej " was changed to comment " Hello "')
+        }
+      })
     })
 
     context('additions', () => {
@@ -171,6 +179,14 @@ describe('Chai HTML', () => {
           expect(e.message).to.equal('text " Hej!" has been added')
         }
       })
+
+      it('detects comment added', () => {
+        try {
+          expect('<p>Hello world!</p><!-- Hej! -->').html.to.equal('<p>Hello world!</p>')
+        } catch (e) {
+          expect(e.message).to.equal('comment " Hej! " has been added')
+        }
+      })
     })
 
     context('deletions', () => {
@@ -195,6 +211,14 @@ describe('Chai HTML', () => {
           expect('<p>Hello world!</p>').html.to.equal('<p>Hello world!</p> Hej!')
         } catch (e) {
           expect(e.message).to.equal('text " Hej!" has been removed')
+        }
+      })
+
+      it('detects comment removed', () => {
+        try {
+          expect('<p>Hello world!</p>').html.to.equal('<p>Hello world!</p> <!-- Hej! -->')
+        } catch (e) {
+          expect(e.message).to.equal('comment " Hej! " has been removed')
         }
       })
     })


### PR DESCRIPTION
This PR augments the explicit error messages with changes made to comments:

```javascript
expect('<p>Hello world!</p><!-- Hej! -->').html.to.equal('<p>Hello world!</p>')
// 'comment " Hej! " has been added'

expect('<p>Hello world!</p>').html.to.equal('<p>Hello world!</p> <!-- Hej! -->')
// 'comment " Hej! " has been removed'

expect('<p>Hello world!</p><!-- Hello -->').html.to.equal('<p>Hello world!</p><!-- Hej -->')
// comment " Hej " was changed to comment " Hello "
```